### PR TITLE
Update kuaidaili.py

### DIFF
--- a/ipproxytool/spiders/proxy/kuaidaili.py
+++ b/ipproxytool/spiders/proxy/kuaidaili.py
@@ -29,7 +29,7 @@ class KuaiDaiLiSpider(BaseSpider):
                 '<tr>\s.*?<td.*?>(.*?)</td>\s.*?<td.*?>(.*?)</td>\s.*?<td.*?>(.*?)</td>\s.*?<td.*?>('
                 '.*?)</td>\s.*?<td.*?>(.*?)</td>\s.*?<td.*?>(.*?)</td>\s.*?<td.*?>(.*?)</td>\s.*?</tr>',
                 re.S)
-        items = re.findall(pattern, response.body)
+        items = re.findall(pattern, response.body.decode('utf-8'))
 
         for item in items:
             proxy = Proxy()


### PR DESCRIPTION
TypeError: cannot use a string pattern on a bytes-like object